### PR TITLE
feat: add page generation

### DIFF
--- a/tools/pageGenerator/plop-templates/pages/index.hbs
+++ b/tools/pageGenerator/plop-templates/pages/index.hbs
@@ -1,0 +1,1 @@
+export { {{name}} } from "./{{name}}";

--- a/tools/pageGenerator/plop-templates/pages/page.hbs
+++ b/tools/pageGenerator/plop-templates/pages/page.hbs
@@ -1,0 +1,11 @@
+import { RequestInfo } from "rwsdk/worker" 
+
+export const {{name}} = ({ ctx }: RequestInfo) => { 
+  
+return (
+  <div>
+    <h1>{{name}} Page</h1>
+    {/* Add your page content here */}
+  </div>
+  ) 
+}

--- a/tools/pageGenerator/plop-templates/pages/routes.hbs
+++ b/tools/pageGenerator/plop-templates/pages/routes.hbs
@@ -1,0 +1,4 @@
+import { route } from "rwsdk/router"; import {
+{{name}}
+} from "./{{name}}"; export const
+{{camelCase name}}Routes = [ route("/{{dashCase name}}", [{{name}}]), ];

--- a/tools/pageGenerator/plop-templates/pages/stories.hbs
+++ b/tools/pageGenerator/plop-templates/pages/stories.hbs
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { {{name}} } from './{{name}}'
+
+const meta: Meta<typeof {{name}}> = {
+  component: {{name}},
+  title: 'Pages/{{name}}',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof {{name}}>
+
+export const Default: Story = {
+  args: {
+    ctx: {
+      user: null,
+      session: null
+    }
+  },
+}
+
+export const WithUser: Story = {
+  args: {
+    ctx: {
+      user: {
+        id: '1',
+        username: 'testuser'
+      },
+      session: {
+        userId: '1'
+      }
+    }
+  },
+}

--- a/tools/pageGenerator/plop-templates/pages/test.hbs
+++ b/tools/pageGenerator/plop-templates/pages/test.hbs
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { {{name}} } from './{{name}}'
+
+describe('{{name}}', () => {
+  it('renders successfully', () => {
+    const mockContext = {
+      ctx: {
+        user: null,
+        session: null
+      }
+    }
+    
+    render(<{{name}} {...mockContext} />)
+    expect(screen.getByText('{{name}} Page')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description
Add a generator option for creating pages. (Similar and copied from component generation functionality).

Note: Page generation functionality adds a option to add routes to worker.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested. Did not see testing set up in package.
Tested
1. npx rwsdk-tools page
2. npx rwsdk-tools component
3. npx rwsdk-tools

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
